### PR TITLE
Fix lh#backup_file invocation

### DIFF
--- a/autoload/lh.vim
+++ b/autoload/lh.vim
@@ -212,7 +212,7 @@ fun! lh#auto_backup() abort
 
     " create new backup if the most recent is older than lh_autobackup_frequency
     if now - recent > g:lh_autobackup_frequency*60
-        call lh#backup_file()
+        call lh#backup_file('')
     endif
 endfun
 


### PR DESCRIPTION
I noticed an error message that the function was not called with right arguments when I saved the file. 

This was brought about since the latest chagnes to this plugin. Simple change; I think this should be good enuf. Thanks for the plugin  :+1: 

